### PR TITLE
Changing the default cron process to do partial indexes if admin config ...

### DIFF
--- a/app/code/community/Hackathon/AsyncIndex/Model/Observer.php
+++ b/app/code/community/Hackathon/AsyncIndex/Model/Observer.php
@@ -74,4 +74,31 @@ class Hackathon_AsyncIndex_Model_Observer extends Mage_Core_Model_Abstract
             throw $e;
         }
     }
+
+    public function runIndex() {
+
+        if ( !Mage::getStoreConfig('system/asyncindex/auto_index') ) {
+            return null;
+        }
+
+        $partialIndex = Mage::getStoreConfig('system/asyncindex/partial_cron_index');
+
+        if($partialIndex) {
+
+            $indexManager = Mage::getModel('hackathon_asyncindex/manager');
+            $pCollection = Mage::getSingleton('index/indexer')->getProcessesCollection();
+
+            /** @var Mage_Index_Model_Process $process */
+            foreach ($pCollection as $process) {
+                $indexManager->executePartialIndex($process);
+            }
+
+        } else {
+
+            // run the normal indexer method
+            $this->unprocessed_events_index();
+
+        }
+
+    }
 }

--- a/app/code/community/Hackathon/AsyncIndex/etc/config.xml
+++ b/app/code/community/Hackathon/AsyncIndex/etc/config.xml
@@ -50,7 +50,7 @@
                     <config_path>system/asyncindex/scheduler_cron_expr</config_path>
                 </schedule>
                 <run>
-                    <model>hackathon_asyncindex/observer::unprocessed_events_index</model>
+                    <model>hackathon_asyncindex/observer::runIndex</model>
                 </run>
 
             </hackathon_asyncindex_events_cron>

--- a/app/code/community/Hackathon/AsyncIndex/etc/system.xml
+++ b/app/code/community/Hackathon/AsyncIndex/etc/system.xml
@@ -40,6 +40,16 @@
                             <show_in_store>0</show_in_store>
                             <validate>validate-number</validate>
                         </event_limit>
+                        <partial_cron_index>
+                            <label>Use Internal Partial Index</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <comment>When enabled the automated cron will perform indexing using Partial Indexing</comment>
+                        </partial_cron_index>
                     </fields>
                 </asyncindex>
             </groups>


### PR DESCRIPTION
...flag is set

I love this module. I have been using it since my site get's  a ton of traffic and I have been steadily working my way through various locks I experience on the DB.
My first index run is at 10am in the morning, and 3/5 times I'll get a lock when this index runs - it will also take ages, sometimes up to an hour.

I tested the partial index by running the shell, and this seems to run way more efficient, and worked this into the module to be run with the cron if the admin config flag is set.

 